### PR TITLE
Fix route distance accuracy — bias toward longer routes

### DIFF
--- a/public/route-generator.js
+++ b/public/route-generator.js
@@ -1,6 +1,7 @@
 const METERS_PER_MILE = 1609.34;
 const METERS_PER_DEGREE_LAT = 111320;
-const ROAD_WINDING_FACTOR = 1.3;
+const ROAD_WINDING_FACTOR = 1.15;
+const OVERSHOOT_BIAS = 1.05; // 5% longer to err on the side of too long
 
 function getWaypointCount(distanceMiles) {
   if (distanceMiles < 5) return 4;
@@ -91,7 +92,7 @@ function polygonCentroid(polygon) {
 function generateWaypoints(startLat, startLng, distanceMiles, radiusOverride, boundary) {
   const count = getWaypointCount(distanceMiles);
   const targetCircumferenceMeters = distanceMiles * METERS_PER_MILE;
-  const radius = radiusOverride || targetCircumferenceMeters / (2 * Math.PI * ROAD_WINDING_FACTOR);
+  const radius = radiusOverride || (targetCircumferenceMeters / (2 * Math.PI * ROAD_WINDING_FACTOR)) * OVERSHOOT_BIAS;
 
   const randomOffset = Math.random() * 2 * Math.PI;
   const startLatRad = (startLat * Math.PI) / 180;
@@ -133,7 +134,9 @@ function adjustWaypoints(startLat, startLng, distanceMiles, actualDistanceMeters
   const currentCircumference = distanceMiles * METERS_PER_MILE;
   const currentRadius = currentCircumference / (2 * Math.PI * ROAD_WINDING_FACTOR);
 
-  const ratio = targetMeters / actualDistanceMeters;
+  // Bias the target slightly long so routes err toward too-long rather than too-short
+  const biasedTarget = targetMeters * OVERSHOOT_BIAS;
+  const ratio = biasedTarget / actualDistanceMeters;
   const adjustedRadius = currentRadius * Math.sqrt(ratio);
 
   return generateWaypoints(startLat, startLng, distanceMiles, adjustedRadius, boundary);
@@ -151,6 +154,7 @@ if (typeof module !== 'undefined' && module.exports) {
     getWaypointCount,
     METERS_PER_MILE,
     METERS_PER_DEGREE_LAT,
-    ROAD_WINDING_FACTOR
+    ROAD_WINDING_FACTOR,
+    OVERSHOOT_BIAS
   };
 }


### PR DESCRIPTION
## Summary
- Routes were consistently ~0.5 miles shorter than the requested distance
- Reduced `ROAD_WINDING_FACTOR` from 1.3 → 1.15 to generate a larger initial waypoint radius, producing longer routes from the first attempt
- Added `OVERSHOOT_BIAS` (1.05) to both initial and iterative radius calculations, systematically erring 5% toward too-long rather than too-short
- Replaced symmetric ±10% tolerance with asymmetric bounds: accept routes up to 10% too long but only 3% too short
- Increased max refinement attempts from 3 → 4 for tighter convergence

## Changes
- `public/route-generator.js` — New `OVERSHOOT_BIAS` constant, updated `ROAD_WINDING_FACTOR`, biased radius in `generateWaypoints()` and `adjustWaypoints()`
- `public/app.js` — Asymmetric tolerance in `computeRoute()` refinement loop, overshoot bias in inline radius adjustment, 4 max attempts
- `tests/route-generator.test.js` — 6 new tests verifying constants, overshoot bias behavior, and radius scaling when routes are too short

## Test plan
- [x] All 74 tests pass (6 new)
- [x] Generate routes at various distances (3, 5, 10, 13, 20 mi) and verify actual distance is closer to target
- [x] Verify routes are no longer consistently short — should now be at or slightly above target distance
- [x] Test with boundary polygon enabled to confirm bias works within constrained areas
- [x] Test on mobile via ngrok to confirm UX is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)