### PR TITLE
Fix loading spinner and UI elements always visible

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -240,6 +240,10 @@ label {
   border-radius: var(--radius);
 }
 
+#route-info[hidden] {
+  display: none;
+}
+
 .info-row {
   display: flex;
   justify-content: space-between;
@@ -270,6 +274,10 @@ label {
   transition: background 0.15s;
 }
 
+#google-maps-link[hidden] {
+  display: none;
+}
+
 #google-maps-link:hover {
   background: #2d9249;
 }
@@ -278,6 +286,10 @@ label {
 #directions {
   display: flex;
   flex-direction: column;
+}
+
+#directions[hidden] {
+  display: none;
 }
 
 #directions-toggle {
@@ -374,6 +386,10 @@ label {
   color: var(--text-muted);
 }
 
+#loading[hidden] {
+  display: none;
+}
+
 .spinner {
   width: 18px;
   height: 18px;
@@ -394,6 +410,10 @@ label {
   border-radius: var(--radius);
   color: var(--error);
   font-size: 0.85rem;
+}
+
+#error[hidden] {
+  display: none;
 }
 
 /* Mobile: bottom sheet */


### PR DESCRIPTION
## Summary
- The "Generating route..." spinner, route info, Google Maps link, directions panel, and error box were all permanently visible instead of hidden by default
- Root cause: CSS rules like `#loading { display: flex; }` override the HTML `hidden` attribute, which relies on the browser's UA stylesheet setting `display: none` — a lower-specificity rule
- Added explicit `[hidden]` selectors (`#loading[hidden] { display: none; }`) for all five affected elements

## Changes
- `public/style.css` — Added `[hidden]` rules for `#loading`, `#route-info`, `#google-maps-link`, `#directions`, and `#error`

## Test plan
- [x] All 74 existing tests pass
- [x] Verify spinner is hidden on initial page load
- [x] Verify spinner appears during route generation and disappears after
- [x] Verify route info, Google Maps link, and directions are hidden until a route is generated
- [x] Verify error message only appears when an error occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)