### PR TITLE
Allow dragging boundary vertices to reposition after misclick

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -442,12 +442,14 @@ function toggleBoundaryMode() {
 }
 
 function handleBoundaryClick(lat, lng) {
+  const index = boundaryVertices.length;
   boundaryVertices.push({ lat, lng });
 
-  // Add a small marker at the vertex
+  // Add a draggable marker at the vertex so it can be repositioned
   const marker = new google.maps.Marker({
     position: { lat, lng },
     map: map,
+    draggable: true,
     icon: {
       path: google.maps.SymbolPath.CIRCLE,
       scale: 6,
@@ -456,8 +458,24 @@ function handleBoundaryClick(lat, lng) {
       strokeColor: '#fff',
       strokeWeight: 2
     },
+    cursor: 'grab',
     zIndex: 50
   });
+
+  // When a vertex is dragged, update its position and refresh the preview
+  marker.addListener('dragend', () => {
+    const pos = marker.getPosition();
+    boundaryVertices[index] = { lat: pos.lat(), lng: pos.lng() };
+    updateBoundaryPreview();
+  });
+
+  // Live preview follows the drag
+  marker.addListener('drag', () => {
+    const pos = marker.getPosition();
+    boundaryVertices[index] = { lat: pos.lat(), lng: pos.lng() };
+    updateBoundaryPreview();
+  });
+
   boundaryMarkers.push(marker);
 
   // Update the live preview polyline


### PR DESCRIPTION
## Summary
- Boundary vertex markers are now **draggable** — if you misclick while drawing a boundary, just drag the point to the correct position
- The polygon preview line updates **in real time** as you drag, so you can see the shape adjust live
- No need to cancel and redraw the entire boundary for a single misplaced point

## Changes
- `public/app.js` — Made boundary markers `draggable: true`, added `drag` and `dragend` listeners that sync the marker position back to `boundaryVertices[index]` and refresh the preview polyline

## Test plan
- [x] All 74 existing tests pass
- [ ] Draw a boundary with 4+ points, drag one vertex — preview updates live
- [ ] Confirm dragging a vertex does NOT add a new point (click event is consumed by the marker)
- [ ] Finish the boundary after dragging — final polygon uses the corrected positions
- [ ] Test on mobile (touch drag) via ngrok

🤖 Generated with [Claude Code](https://claude.com/claude-code)