### PR TITLE
Add intro blurb and how-to guide above controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,16 @@
   <div id="controls">
     <h1>Training Routes</h1>
 
+    <div id="intro">
+      <p>Generate a loop running route from any starting point. Set a distance, hit Generate, and get a route with turn-by-turn directions you can open in Google Maps.</p>
+      <ol>
+        <li>Search for a location or click the map to set your start</li>
+        <li>Pick a distance or enter your own</li>
+        <li>Optionally draw a boundary to keep the route within an area</li>
+        <li>Hit <strong>Generate Route</strong></li>
+      </ol>
+    </div>
+
     <label for="search">Starting Point</label>
     <input id="search" type="text" placeholder="Search location or click the map">
 

--- a/public/style.css
+++ b/public/style.css
@@ -58,6 +58,36 @@ body {
   margin-bottom: 4px;
 }
 
+#intro {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius);
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+#intro p {
+  margin: 0;
+}
+
+#intro ol {
+  margin: 0;
+  padding-left: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+#intro li strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
 label {
   font-size: 0.75rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Adds a short description of the app and a 4-step how-to above the controls panel
- Styled subtly to blend with the existing dark panel UI (muted background, same border radius/color scheme)

## Test plan
- [x] Open the app and confirm the intro block appears above the Starting Point field
- [x] Verify the text is readable and the styling fits the existing dark theme
- [x] Check mobile layout — intro should still display cleanly in the bottom sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)