### PR TITLE
Fix map centering after route generation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -294,11 +294,18 @@ function drawRoute(routeData) {
     map: map
   });
 
-  // Fit map to route
+  // Fit map to show the full route, accounting for the controls panel
   const bounds = new google.maps.LatLngBounds();
   path.forEach(point => bounds.extend(point));
   bounds.extend(startMarker.getPosition());
-  map.fitBounds(bounds, { top: 20, right: 20, bottom: 20, left: 360 });
+  lastWaypoints.forEach(wp => bounds.extend({ lat: wp.lat, lng: wp.lng }));
+  const controlsEl = document.getElementById('controls');
+  const panelWidth = controlsEl ? controlsEl.offsetWidth + 32 : 20;
+  const isMobile = window.innerWidth <= 768;
+  const padding = isMobile
+    ? { top: 20, right: 20, bottom: 340, left: 20 }
+    : { top: 20, right: 20, bottom: 20, left: panelWidth };
+  map.fitBounds(bounds, padding);
 }
 
 function clearRoute() {


### PR DESCRIPTION
## Summary

- After clicking **Generate Route**, the map now reliably centers and zooms to show the full route
- Replaced the hardcoded `left: 360` padding with a dynamic value read from the actual `#controls` panel `offsetWidth`, so the route is never obscured by the controls overlay
- Added responsive mobile support: on screens ≤ 768px the controls panel sits at the bottom of the viewport, so `fitBounds` now uses bottom padding instead of left padding
- Explicitly extends the bounds with all `lastWaypoints` (in addition to the decoded polyline path and the start marker) to guarantee all route points are captured

## Test plan

- [ ] Generate a route and confirm the map auto-zooms to frame the full route
- [ ] Resize the browser to mobile width (≤ 768px) and confirm the route is visible above the bottom panel
- [ ] Run `npm test` — all existing backend/logic tests pass (frontend change not covered by unit tests)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)