### PR TITLE
Move GitHub link to header as icon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,14 @@
   <div id="map"></div>
 
   <div id="controls">
-    <h1>Training Routes</h1>
+    <div id="panel-header">
+      <h1>Training Routes</h1>
+      <a id="github-link" href="https://github.com/thejoeyg/training-routes" target="_blank" rel="noopener noreferrer" aria-label="GitHub repository">
+        <svg height="20" width="20" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+      </a>
+    </div>
 
     <div id="intro">
       <p>Generate a loop running route from any starting point. Set a distance, hit Generate, and get a route with turn-by-turn directions you can open in Google Maps.</p>
@@ -82,11 +89,7 @@
     <div id="error" hidden></div>
   </div>
 
-  <footer>
-    <a href="https://github.com/thejoeyg/training-routes" target="_blank" rel="noopener noreferrer">GitHub</a>
-  </footer>
-
-  <script src="route-generator.js"></script>
+<script src="route-generator.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/public/style.css
+++ b/public/style.css
@@ -51,11 +51,28 @@ body {
   overflow-y: auto;
 }
 
+#panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
 #controls h1 {
   font-size: 1.25rem;
   font-weight: 700;
   letter-spacing: -0.02em;
-  margin-bottom: 4px;
+}
+
+#github-link {
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+
+#github-link:hover {
+  color: var(--text);
 }
 
 #intro {
@@ -528,17 +545,3 @@ label {
   display: none;
 }
 
-footer {
-  text-align: center;
-  margin-top: 4px;
-}
-
-footer a {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  text-decoration: none;
-}
-
-footer a:hover {
-  color: var(--text);
-}


### PR DESCRIPTION
## Summary

- Removes the footer text link at the bottom of the controls panel
- Adds a GitHub SVG logo icon to the top of the panel, right-aligned with the "Training Routes" heading
- Icon is muted by default, brightens on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)